### PR TITLE
feat(mcp): server.health + server.stats + client flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,10 @@ mcp-policy:
 	@target/debug/devit-mcp --cmd 'target/debug/devit-mcpd --yes --devit-bin target/debug/devit' --policy | jq
 
 mcp-health:
-	@target/debug/devit-mcp --cmd 'target/debug/devit-mcpd --yes --devit-bin target/debug/devit' --health | jq
+	@target/debug/devit-mcp --cmd 'target/debug/devit-mcpd --yes --devit-bin target/debug/devit' --call server.health --json '{}' | jq
 
 mcp-stats:
-	@target/debug/devit-mcp --cmd 'target/debug/devit-mcpd --yes --devit-bin target/debug/devit' --stats | jq
+	@target/debug/devit-mcp --cmd 'target/debug/devit-mcpd --yes --devit-bin target/debug/devit' --call server.stats --json '{}' | jq
 
 e2e-mcp:
 	@set -e; \
@@ -192,9 +192,9 @@ e2e-mcp:
 	SRV="target/debug/devit-mcpd --yes --devit-bin target/debug/devit"; \
 	( $$SRV & echo $$! > .devit/mcpd.pid ); \
 	sleep 0.5; \
-	target/debug/devit-mcp --cmd "$$SRV" --policy >/dev/null; \
-	target/debug/devit-mcp --cmd "$$SRV" --health >/dev/null || true; \
-	target/debug/devit-mcp --cmd "$$SRV" --stats >/dev/null || true; \
+		target/debug/devit-mcp --cmd "$$SRV" --policy >/dev/null; \
+		target/debug/devit-mcp --cmd "$$SRV" --call server.health --json '{}' >/dev/null || true; \
+		target/debug/devit-mcp --cmd "$$SRV" --call server.stats --json '{}' >/dev/null || true; \
 	echo '{"tool":"echo","args":{"msg":"ok"}}' | target/debug/devit-mcp --cmd "$$SRV" --call devit.tool_call --json @- >/dev/null || true; \
 	kill $$(cat .devit/mcpd.pid) 2>/dev/null || true; \
 	rm -f .devit/mcpd.pid; \

--- a/crates/cli/src/bin/devit-mcp.rs
+++ b/crates/cli/src/bin/devit-mcp.rs
@@ -51,6 +51,12 @@ struct Cli {
     /// Affiche la politique serveur via MCP (server.policy)
     #[arg(long, action = ArgAction::SetTrue)]
     policy: bool,
+    /// Affiche la santé serveur via MCP (server.health)
+    #[arg(long, action = ArgAction::SetTrue)]
+    health: bool,
+    /// Affiche les stats serveur via MCP (server.stats)
+    #[arg(long, action = ArgAction::SetTrue)]
+    stats: bool,
 
     /// Timeout par message (secs). Par défaut: DEVIT_TIMEOUT_SECS ou 30
     #[arg(long = "timeout-secs")]
@@ -108,6 +114,18 @@ fn real_main() -> Result<()> {
 
     if cli.policy {
         let v = client.tool_call("server.policy", serde_json::json!({}))?;
+        safe_print_json(&v)?;
+        return Ok(());
+    }
+
+    if cli.health {
+        let v = client.tool_call("server.health", serde_json::json!({}))?;
+        safe_print_json(&v)?;
+        return Ok(());
+    }
+
+    if cli.stats {
+        let v = client.tool_call("server.stats", serde_json::json!({}))?;
         safe_print_json(&v)?;
         return Ok(());
     }

--- a/scripts/e2e_mcp.sh
+++ b/scripts/e2e_mcp.sh
@@ -5,8 +5,8 @@ SRV="target/debug/devit-mcpd --yes --devit-bin target/debug/devit"
 ( $SRV & echo $! > .devit/mcpd.pid )
 sleep 0.5
 target/debug/devit-mcp --cmd "$SRV" --policy >/dev/null
-target/debug/devit-mcp --cmd "$SRV" --health >/dev/null || true
-target/debug/devit-mcp --cmd "$SRV" --stats >/dev/null || true
+target/debug/devit-mcp --cmd "$SRV" --call server.health --json '{}' >/dev/null || true
+target/debug/devit-mcp --cmd "$SRV" --call server.stats --json '{}' >/dev/null || true
 echo '{"tool":"echo","args":{"msg":"ok"}}' | target/debug/devit-mcp --cmd "$SRV" --call devit.tool_call --json @- >/dev/null || true
 kill $(cat .devit/mcpd.pid) 2>/dev/null || true
 rm -f .devit/mcpd.pid


### PR DESCRIPTION
- **docs(mcp): refresh --help/README; Makefile targets; E2E script**
- **docs(mcp): use generic --call for health/stats in Makefile and E2E script**
- **feat(mcp): add server.health (uptime/deps) and server.stats (per-tool counters) + client flags**
